### PR TITLE
increase max body length for commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,7 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     defaultIgnores: false,
+    rules: {
+        'body-max-length': [0, 'always', '120']
+    }
 };


### PR DESCRIPTION
This minor bump is to handle dependabot without turning off checks.